### PR TITLE
[HiggsFit] Fix name of dataset to prevent shadowing problems.

### DIFF
--- a/notebooks/HiggsFit.ipynb
+++ b/notebooks/HiggsFit.ipynb
@@ -139,7 +139,7 @@
     }
    ],
    "source": [
-    "RooDataSet data(\"data\",\"data\",*x,RooFit::Import(tree) )"
+    "RooDataSet dataset(\"data\",\"data\",*x,RooFit::Import(tree) )"
    ]
   },
   {
@@ -321,7 +321,7 @@
     }
    ],
    "source": [
-    "auto r = model->fitTo(data, RooFit::Minimizer(\"Minuit\"),RooFit::Save(true), RooFit::Offset(true));"
+    "auto r = model->fitTo(dataset, RooFit::Minimizer(\"Minuit\"),RooFit::Save(true), RooFit::Offset(true));"
    ]
   },
   {
@@ -354,7 +354,7 @@
    ],
    "source": [
     "auto plot = x->frame();\n",
-    "data.plotOn(plot);\n",
+    "dataset.plotOn(plot);\n",
     "model->plotOn(plot);\n",
     "model->plotOn(plot, RooFit::Components(\"bmodel\"),RooFit::LineStyle(kDashed));\n",
     "model->plotOn(plot, RooFit::Components(\"smodel\"),RooFit::LineColor(kRed));\n",


### PR DESCRIPTION
Notebook doesn't execute, since C++17's `std::data` is imported via `using namespace std;`. `data` can therefore not be used, any more.